### PR TITLE
Check for out of bounds array index access to suppress mobx.array warnings

### DIFF
--- a/src/MobxModel.js
+++ b/src/MobxModel.js
@@ -69,7 +69,14 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/model/Model', 'sap/ui/model/Context'
 
         var partsLength = parts.length;
         for (var i = 0; i < partsLength && !isNil(currentNode); i++) {
-          currentNode = currentNode[parts[i]];
+
+		  // Check for out of bounds array index access to suppress warnings
+		  //	"[mobx.array] Attempt to read an array index (1) that is out of bounds (1). Please check length first. Out of bound indices will not be tracked by MobX"
+          if(!mobx.isObservableArray(currentNode) || parts[i] < currentNode.length ) {
+        	currentNode = currentNode[parts[i]];
+          } else {
+          	currentNode = null;
+          }
         }
 
         return currentNode;

--- a/test/MobxModel.js
+++ b/test/MobxModel.js
@@ -97,7 +97,7 @@ sap.ui.define(['sap/ui/mobx/MobxModel', 'sap/ui/model/Context'], function (MobxM
       });
 
       it('out of bounds array index access does not generate MobX warning', function () {
-        model.getProperty('/nested/array/2').should.equal(null);
+        model.getProperty('/nested/array/2').should.be.a('null');
       });
     });
 

--- a/test/MobxModel.js
+++ b/test/MobxModel.js
@@ -97,7 +97,7 @@ sap.ui.define(['sap/ui/mobx/MobxModel', 'sap/ui/model/Context'], function (MobxM
       });
 
       it('out of bounds array index access does not generate MobX warning', function () {
-        model.getProperty('/nested/array/2').should.be.a('null');
+        should.not.exist(model.getProperty('/nested/array/2'));
       });
     });
 

--- a/test/MobxModel.js
+++ b/test/MobxModel.js
@@ -96,6 +96,9 @@ sap.ui.define(['sap/ui/mobx/MobxModel', 'sap/ui/model/Context'], function (MobxM
         model.getProperty('name', context).should.equal('bar');
       });
 
+      it('out of bounds array index access does not generate MobX warning', function () {
+        model.getProperty('/nested/array/2').should.equal(null);
+      });
     });
 
   });


### PR DESCRIPTION
Check for out of bounds array index access to suppress warnings "[mobx.array] Attempt to read an array index (1) that is out of bounds (1). Please check length first. Out of bound indices will not be tracked by MobX"

These warnings are present on the [Plunker example](https://plnkr.co/edit/zqrOKW?p=preview) too.