### PR TITLE
Fixed ui5 model size issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openui5-mobx-model",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ui5 bindings for mobx",
   "main": "src/MobxModel.js",
   "types": "types.d.ts",

--- a/src/MobxModel.js
+++ b/src/MobxModel.js
@@ -15,6 +15,9 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/model/Model', 'sap/ui/model/Context'
         });
 
         AbstractModel.apply(this, arguments);
+        // Parent class sap.ui.model.Model has a default size limitation of 100 entries
+        // which may and does cause problems. 
+        this.setSizeLimit(Number.MAX_SAFE_INTEGER);
       },
       getObservable: function () {
         return this._observable;


### PR DESCRIPTION
MobxModel's parent class sap.ui.model.Model has a default size limitation of 100 entries which may and does cause problems. 
